### PR TITLE
Fix UB In NSArray:chuzzle

### DIFF
--- a/Sources/ChuzzleKit.m
+++ b/Sources/ChuzzleKit.m
@@ -35,6 +35,9 @@
 @implementation NSArray (Chuzzle)
 
 - (instancetype)chuzzle {
+    if (self.count == 0) {
+        return nil;
+    }
     id objs[self.count];
     NSUInteger x = 0;
     for (__strong id obj in self) {


### PR DESCRIPTION
When calling chuzzle on a zero-length instance of NSArray, a C-Array of length 0 is created. 
This doesn't cause any actual problems on any platforms I've tested, but it trips the undefined behaviour sanitizer in Xcode which is annoying and drowns out any useful warnings.