### PR TITLE
 Fix UB In NSDictionary:chuzzle

### DIFF
--- a/Sources/ChuzzleKit.m
+++ b/Sources/ChuzzleKit.m
@@ -14,6 +14,9 @@
 @implementation NSDictionary (Chuzzle)
 
 - (id)chuzzle {
+    if (self.count == 0) {
+        return nil;
+    }
     id objs[self.count];
     id keys[self.count];
     NSUInteger x = 0;


### PR DESCRIPTION
Same as last month for NSArray:
When calling chuzzle on a zero-length instance of NSDictionary, a C-Array of length 0 is created. It doesn't currently cause any problems, but trips the undefined behaviour sanitizer in Xcode which is annoying.